### PR TITLE
Improve request handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,8 +25,8 @@ function query() {
     $qs = [];
     $components = explode("/", $_SERVER['REQUEST_URI']);
     @[$root, $page, $name] = $components;
-    $qs["page"] = $page;
-    $qs["name"] = $name;
+    $qs["page"] = sanitize_text_field($page);
+    $qs["name"] = sanitize_text_field($name);
     return $qs;
 }
 ?>
@@ -256,8 +256,9 @@ apply_filters('the_content', get_post_field('post_content', $page->id));
         $gallery = (array)$gallery;
         if (isset($gallery["fields"]["gallery_link"])) {
             $gallery_url = "https://".$gallery["fields"]["gallery_link"];
-            $images = file_get_contents($gallery_url);
-            if ($images) {
+            $response = wp_safe_remote_get($gallery_url);
+            if (!is_wp_error($response)) {
+                $images = wp_remote_retrieve_body($response);
                 $dom = new DomDocument();
                 $dom->loadHTML($images);
                 foreach ($dom->getElementsByTagName('a') as $item) {


### PR DESCRIPTION
## Summary
- sanitize request parameters in `wp.php`
- add validation of `post_type` and `name`
- fetch remote resources via `wp_safe_remote_get`
- sanitize URL path segments in `index.php`

## Testing
- `npm test` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684f6100a97c8330a20d0faea02a8d78

## Summary by Sourcery

Improve request handling by sanitizing and validating all incoming parameters, replacing raw HTTP calls with WordPress-safe APIs, and adding error handling for invalid inputs.

Enhancements:
- Consolidate and sanitize request data in wp.php using sanitize_text_field and esc_url_raw
- Validate post_type and name parameters against allowed values and return errors on invalid input
- Replace file_get_contents calls with wp_safe_remote_get/wp_safe_remote_head and proper error checking
- Add default error response for unsupported actions in the request switch
- Sanitize URL path segments in index.php before routing