### PR TITLE
Restore prototype extensions with provided helper

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,18 +1,17 @@
 Object.defineProperty(Object.prototype, "define", {
     configurable: true,
     enumerable: false,
-    writable: true,
+    writable: false,
     value: function (name, value) {
-        if (Object[name]) {
-            delete Object[name];
+        if (this.hasOwnProperty(name)) {
+            delete this[name];
         }
         Object.defineProperty(this, name, {
             configurable: true,
             enumerable: false,
-            writable: true,
             value: value
         });
-        return this;
+        return this[name];
     }
 });
 Object.prototype.define("map", function (mapFn) {
@@ -31,7 +30,7 @@ Object.prototype.define("each", function (fn) {
     }
     return this;
 });
-Array.prototype.define("each", Array.prototype.forEach)
+Array.prototype.define("each", Array.prototype.forEach);
 String.prototype.define('toTitleCase', function () {
     return this.replace(/\w\S*/g, function (txt) {
         return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
@@ -39,11 +38,11 @@ String.prototype.define('toTitleCase', function () {
 });
 String.prototype.define('escapeHTML', function () {
     let replacements = { "<": "&lt;", ">": "&gt;", "&": "&amp;", "'": "&apos;", "\"": "&quot;" };
-    return this.replace(/[<>&'"]/g, function (character) {
+    return this.replace(/[<>&'\"]/g, function (character) {
         return replacements[character];
     });
 });
-Math.define("nativeRound", Math.round)
+Math.define("nativeRound", Math.round);
 Math.define("round", function (i, n) {
     return +i.toFixed(n);
 });
@@ -94,7 +93,7 @@ function query() {
         return this.each(function() {
             let $this = $(this);
             if (tree) $this = $(this).find(tree);
-            
+
             let unsortedElems = $this.children(childElem);
             let elems = unsortedElems.clone();
 


### PR DESCRIPTION
## Summary
- reintroduce Object.prototype.define using user's code
- attach helper methods via `.define`
- update counter and title logic to use prototype helpers

## Testing
- `npm test` *(fails: Cannot find package 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684f68780c248330ac6f7f12ab6f5c9f

## Summary by Sourcery

Rework the prototype define helper and streamline related prototype extensions for consistency.

Enhancements:
- Make Object.prototype.define non-writable, delete existing own properties via hasOwnProperty, and return the newly defined value
- Add missing semicolons to all .define invocations for consistent syntax
- Correct the HTML escape regex to properly include double quotes

Chores:
- Remove extraneous whitespace in the query function for cleaner formatting