### PR TITLE
Add README node script guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ installations:
 Run any of these tools with `php tools/<script-name.php>` once WordPress is
 configured and accessible.
 
+#### Running Node Scripts
+
+Some migration utilities are written in Node.js, such as `tools/scrape.js`.
+Install dependencies in the `tools/` directory with:
+
+```bash
+npm install
+```
+
+Then execute a script using `node` and any required arguments:
+
+```bash
+node tools/scrape.js <url>
+```
+
+Replace `<url>` with the site you want to scrape or process.
+
 ### Running the Site Locally
 
 With DDEV running, visit the site at the URL printed by `ddev start` (for


### PR DESCRIPTION
## Summary
- document how to run Node-based scripts in `tools`
- show example commands for installing and running `tools/scrape.js`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f71ff73b8833090e200e2bcd52105

## Summary by Sourcery

Documentation:
- Add instructions for installing and running Node-based scripts in the tools directory