### PR TITLE
Add URL argument to scraping tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Some data migration utilities rely on Node.js packages. Change into the
 `tools/` directory and run `npm install` to install them. If Puppeteer is not
 needed, you can set the `PUPPETEER_SKIP_DOWNLOAD=1` environment variable.
 
+Run `node scrape.js [url]` from inside the `tools/` directory to save the
+rendered HTML from a page. If `url` is omitted, it defaults to
+`https://dev.bosphilly.com/`.
+
 ### Data Migration Scripts
 
 The `tools/` folder contains PHP scripts that help move data between

--- a/tools/scrape.js
+++ b/tools/scrape.js
@@ -2,7 +2,7 @@ import puppeteer from 'puppeteer';
 import fs from 'fs';
 import pretty from "pretty";
 
-const url = 'https://dev.bosphilly.com/';
+const url = process.argv[2] || 'https://dev.bosphilly.com/';
 
 try {
     const browser = await puppeteer.launch({


### PR DESCRIPTION
## Summary
- make `tools/scrape.js` accept an optional URL argument
- document usage of `scrape.js` in the README

## Testing
- `node --check tools/scrape.js`
- `npm test` *(fails: Cannot find package 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684f72065bd08330a499e9f8dc7b242b