### PR TITLE
Revert templates/scripts.php to original script loading

### DIFF
--- a/templates/scripts.php
+++ b/templates/scripts.php
@@ -4,8 +4,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pluralize/8.0.0/pluralize.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/konami@1.6.3/konami.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-<script src="utils.js"></script>
-<script src="wp.js"></script>
+<script src="/utils.js"></script>
+<script src="/wp.js"></script>
 <script>
 let route = query();
 

--- a/templates/scripts.php
+++ b/templates/scripts.php
@@ -1,95 +1,12 @@
-<script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11" defer></script>
-<script src="utils.js" defer></script>
-<script src="wp.js" defer></script>
-<script type="module">
-  // Example: lightbox only when a gallery image is clicked
-  document.addEventListener('click', async (e)=>{
-    const a = e.target.closest('a');
-    if(!a) return;
-    if (a.matches('[data-lightbox]')) {
-      e.preventDefault();
-      if (!window.lightbox) {
-        try {
-          await Promise.all([
-            import('https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/js/lightbox.min.js'),
-            new Promise((res, rej) => {
-              const l = document.createElement('link');
-              l.rel = 'stylesheet';
-              l.href = 'https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/css/lightbox.min.css';
-              l.onload = res;
-              l.onerror = () => rej(new Error('Failed to load lightbox stylesheet.'));
-              document.head.appendChild(l);
-            })
-          ]);
-        } catch (err) {
-          if (window.Swal) {
-            Swal.fire({
-              icon: 'error',
-              title: 'Lightbox failed to load',
-              text: err.message || 'Please check your connection and try again.',
-            });
-          } else {
-            alert('Lightbox failed to load: ' + (err.message || 'Please check your connection and try again.'));
-          }
-          return;
-        }
-      }
-      lightbox.start($(a)[0]);
-    }
-  });
-
-  // Defer non-critical libs until idle
-  const deferLib = (src)=> new Promise((res)=>{
-    const s=document.createElement('script'); s.src=src; s.defer=true; s.onload=res; document.head.appendChild(s);
-  });
-  requestIdleCallback?.(()=>{
-    deferLib('https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js');
-    deferLib('https://cdnjs.cloudflare.com/ajax/libs/pluralize/8.0.0/pluralize.min.js');
-    deferLib('https://cdn.jsdelivr.net/npm/konami@1.6.3/konami.min.js');
-  });
-
-  // Lazy-load hero video when idle and in view, with IntersectionObserver polyfill for legacy browsers
-  const startHeroVideo = () => {
-    const v = document.getElementById('heroVideo');
-    if (v && !navigator.connection?.saveData) {
-      const observeVideo = () => {
-        const io = new IntersectionObserver(([e]) => {
-          if (e.isIntersecting) {
-            v.load();
-            v.play().catch(() => {});
-            io.disconnect();
-          }
-        });
-        io.observe(v);
-      };
-      if ('IntersectionObserver' in window) {
-        observeVideo();
-      } else {
-        // Load IntersectionObserver polyfill for legacy browsers
-        const polyfillScript = document.createElement('script');
-        polyfillScript.src = 'https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver';
-        polyfillScript.onload = observeVideo;
-        document.head.appendChild(polyfillScript);
-      }
-    }
-  };
-  if (window.requestIdleCallback) {
-    requestIdleCallback(startHeroVideo);
-  } else {
-    startHeroVideo();
-  }
-</script>
+<script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/js/lightbox.min.js"></script>
+<script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pluralize/8.0.0/pluralize.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/konami@1.6.3/konami.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="utils.js"></script>
+<script src="wp.js"></script>
 <script>
-if (typeof query !== 'function') {
-    function query() {
-        let qs = {}, slice = 1;
-        let [page, name] = [...window.location.pathname.split("/").slice(slice)];
-        qs.page = page;
-        qs.name = name;
-        return qs;
-    }
-}
 let route = query();
 
 debug = getQueryString().debug;
@@ -343,7 +260,7 @@ $(async () => {
             confirmButtonText: `
 <a href="webcal://calendar.google.com/calendar/ical/c_e5ccfcf9265560b5a19219e3e0cc2047926d5adb287c163e59322c00137ec065%40group.calendar.google.com/public/basic.ics">Subscribe</a>
   `,
-            iconHtml: `<?= icon('calendar-days') ?>`,
+            iconHtml: `<i class="fa-solid fa-calendar-days"></i>`,
             showCloseButton: true,
             showCancelButton: true,
             iconColor: "#ed208b",

--- a/templates/scripts.php
+++ b/templates/scripts.php
@@ -260,7 +260,7 @@ $(async () => {
             confirmButtonText: `
 <a href="webcal://calendar.google.com/calendar/ical/c_e5ccfcf9265560b5a19219e3e0cc2047926d5adb287c163e59322c00137ec065%40group.calendar.google.com/public/basic.ics">Subscribe</a>
   `,
-            iconHtml: `<i class="fa-solid fa-calendar-days"></i>`,
+            iconHtml: `<?= icon('calendar-days') ?>`,
             showCloseButton: true,
             showCancelButton: true,
             iconColor: "#ed208b",


### PR DESCRIPTION
## Summary
- Restore synchronous script tags in `templates/scripts.php` to match pre-refactor behavior

## Testing
- `npm run lint` *(fails: 351 problems — existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8681d09dc8330a0a15c28070d4a8e

## Summary by Sourcery

Revert scripts.php to use synchronous script tags and remove dynamic loading logic, restoring previous behavior, and update SweetAlert icon markup.

Enhancements:
- Restore original synchronous loading of external and utility scripts in templates/scripts.php
- Remove dynamic import, requestIdleCallback, and IntersectionObserver logic for deferred and lazy-loaded scripts
- Update SweetAlert iconHtml to use an inline Font Awesome <i> tag instead of the PHP icon helper